### PR TITLE
Remove 404 page from list of technical tasks

### DIFF
--- a/views/technical_tasks.erb
+++ b/views/technical_tasks.erb
@@ -1,5 +1,4 @@
 - [ ] Add an unstyled theme to this repo
-- [ ] Include a `404.html` template
 - [ ] Create an [orphan `gh-pages` branch](https://help.github.com/articles/creating-project-pages-manually/#create-a-gh-pages-branch) for building the site into
 - [ ] Configure this repo to build on Travis CI
 - [ ] Add required plugins and configure them


### PR DESCRIPTION
This is now part of the [base_template](https://github.com/theyworkforyou/base_template).
