### PR TITLE
Link to base_template from technical tasks

### DIFF
--- a/views/technical_tasks.erb
+++ b/views/technical_tasks.erb
@@ -1,4 +1,4 @@
-- [ ] Add an unstyled theme to this repo
+- [ ] Add an unstyled theme to this repo, use the [base_template](https://github.com/theyworkforyou/base_template) as a starting point
 - [ ] Create an [orphan `gh-pages` branch](https://help.github.com/articles/creating-project-pages-manually/#create-a-gh-pages-branch) for building the site into
 - [ ] Configure this repo to build on Travis CI
 - [ ] Add required plugins and configure them


### PR DESCRIPTION
Point people to the base template from the list of technical tasks.
