### PR TITLE
Remove gh-pages orphan branch link

### DIFF
--- a/views/technical_tasks.erb
+++ b/views/technical_tasks.erb
@@ -1,5 +1,4 @@
 - [ ] Add an unstyled theme to this repo, use the [base_template](https://github.com/theyworkforyou/base_template) as a starting point
-- [ ] Create an [orphan `gh-pages` branch](https://help.github.com/articles/creating-project-pages-manually/#create-a-gh-pages-branch) for building the site into
 - [ ] [Configure this repo to build on Travis CI](https://github.com/theyworkforyou/documentation/blob/5c2d04459817ef2b8ef05378f0b11304cb2ada75/README.md#deploying-to-github-pages)
 - [ ] Add required plugins and configure them
 - [ ] Add this country to the datasource updater


### PR DESCRIPTION
This is already mentioned in the Travis setup instructions that are linked to, so doesn't need to be repeated in the list of technical tasks.
